### PR TITLE
Travis-CI for Matlab, setup robustness

### DIFF
--- a/+gemini3d/+fileio/download_and_extract.m
+++ b/+gemini3d/+fileio/download_and_extract.m
@@ -25,10 +25,12 @@ urls = gemini3d.vendor.ini2struct.ini2struct(url_ini);
 
 zipfile = fullfile(data_dir, "test" + test_name + ".zip");
 
-if ~isfile(zipfile) || dir(zipfile).bytes < 10000  % missing or empty zip
-  web_opts = weboptions('Timeout', 15, ...  % 5 seconds has nuisance timeouts
-    'CertificateFilename', '' ...  % HPC tend to have outdated or missing SSL certs
-    );
+if ~isfile(zipfile) || ...
+    dir(zipfile).bytes < 10000  % missing or empty zip
+
+  web_opts = weboptions('Timeout', 15);  % 5 seconds has nuisance timeouts
+    % 'CertificateFilename', '' ...  % HPC tend to have outdated or missing SSL certs
+
   k = "url";
   url = urls.("x" + test_name).(k);
   websave(zipfile, url, web_opts);

--- a/+gemini3d/+fileio/download_and_extract.m
+++ b/+gemini3d/+fileio/download_and_extract.m
@@ -25,10 +25,11 @@ urls = gemini3d.vendor.ini2struct.ini2struct(url_ini);
 
 zipfile = fullfile(data_dir, "test" + test_name + ".zip");
 
-if ~isfile(zipfile)
+if ~isfile(zipfile) || dir(zipfile).bytes < 10000  % missing or empty zip
+  web_opts = weboptions('Timeout', 15);
   k = "url";
   url = urls.("x" + test_name).(k);
-  websave(zipfile, url);
+  websave(zipfile, url, web_opts);
 end
 
 %% md5sum check

--- a/+gemini3d/+fileio/download_and_extract.m
+++ b/+gemini3d/+fileio/download_and_extract.m
@@ -26,7 +26,9 @@ urls = gemini3d.vendor.ini2struct.ini2struct(url_ini);
 zipfile = fullfile(data_dir, "test" + test_name + ".zip");
 
 if ~isfile(zipfile) || dir(zipfile).bytes < 10000  % missing or empty zip
-  web_opts = weboptions('Timeout', 15);
+  web_opts = weboptions('Timeout', 15, ...  % 5 seconds has nuisance timeouts
+    'CertificateFilename', '' ...  % HPC tend to have outdated or missing SSL certs
+    );
   k = "url";
   url = urls.("x" + test_name).(k);
   websave(zipfile, url, web_opts);

--- a/+gemini3d/+sys/build_gemini3d.m
+++ b/+gemini3d/+sys/build_gemini3d.m
@@ -9,6 +9,9 @@ if isempty(gemini_root)
   error("build_gemini3d:environment_error", "please run mat_gemini/setup.m to setup your environment")
 end
 
+exe = gemini3d.posix(exe);
+gemini_root = gemini3d.posix(gemini_root);
+
 build_dir = fileparts(exe);
 
 assert(gemini3d.sys.cmake_atleast("3.15"), "CMake >= 3.15 required for Gemini")

--- a/+gemini3d/+sys/build_gemini3d.m
+++ b/+gemini3d/+sys/build_gemini3d.m
@@ -11,6 +11,8 @@ end
 
 build_dir = fileparts(exe);
 
+assert(gemini3d.sys.cmake_atleast("3.15"), "CMake >= 3.15 required for Gemini")
+
 cfg_cmd = "cmake -B" + build_dir + " -S" + gemini_root;
 ret = system(cfg_cmd);
 if ret ~= 0

--- a/+gemini3d/+sys/build_gemini3d.m
+++ b/+gemini3d/+sys/build_gemini3d.m
@@ -10,7 +10,8 @@ if isempty(gemini_root)
 end
 
 exe = gemini3d.posix(exe);
-gemini_root = gemini3d.posix(gemini_root);
+% must be absolute path for Unix-like, where cannot traverse upwards from non-existent dir
+gemini_root = gemini3d.posix(gemini3d.fileio.absolute_path(gemini_root));
 
 build_dir = fileparts(exe);
 

--- a/+gemini3d/+sys/build_gemini3d.m
+++ b/+gemini3d/+sys/build_gemini3d.m
@@ -14,7 +14,13 @@ gemini_root = gemini3d.posix(gemini_root);
 
 build_dir = fileparts(exe);
 
-assert(gemini3d.sys.cmake_atleast("3.15"), "CMake >= 3.15 required for Gemini")
+if ~gemini3d.sys.cmake_atleast("3.15")
+  error("build_gemini3d:environment_error", "CMake >= 3.15 required for Gemini")
+end
+
+if ~isfolder(gemini_root)
+  error("build_gemini3d:file_not_found", "gemini_root source directory not found: " + gemini_root)
+end
 
 cfg_cmd = "cmake -B" + build_dir + " -S" + gemini_root;
 ret = system(cfg_cmd);

--- a/+gemini3d/+sys/cmake_atleast.m
+++ b/+gemini3d/+sys/cmake_atleast.m
@@ -1,0 +1,16 @@
+function r = cmake_atleast(min_version)
+arguments
+  min_version (1,1) string
+end
+
+[ret, msg] = system("cmake --version");
+if ret ~= 0
+  error("cmake_atleast:runtime_error", "problem getting CMake version " + msg)
+end
+
+match = regexp(msg, "(?<=cmake version )(\d+\.\d+\.\d+)", 'match');
+
+r = gemini3d.version_atleast(match{1}, min_version);
+
+
+end

--- a/+gemini3d/+tests/test_dryrun.m
+++ b/+gemini3d/+tests/test_dryrun.m
@@ -1,7 +1,8 @@
 name = "2dew_eq";
 
 cwd = fileparts(mfilename('fullpath'));
-
+% setup so GEMINI_ROOT is set
+run(fullfile(cwd, "../../setup.m"))
 % get files if needed
 gemini3d.fileio.download_and_extract(name, fullfile(cwd, "data"))
 %% MPIexec

--- a/+gemini3d/posix.m
+++ b/+gemini3d/posix.m
@@ -1,0 +1,13 @@
+function ppath = posix(varargin)
+% convert a path or sequence of path components to a Posix path separated
+% with "/" even on Windows.
+% If Windows path also have escaping "\" this breaks--this is fixable by
+% regex so let us know if this becomes an issue.
+
+ppath = fullfile(varargin{:});
+
+if ispc
+  ppath = strrep(ppath, "\", "/");
+end
+
+end % function

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ language: matlab
 matlab:
 - latest
 
+os:
+- linux
+
 git:
 - depth: 3
 - quiet: true
@@ -24,3 +27,7 @@ addons:
 
 before_script:
 - export PATH=/snap/bin:$PATH
+
+script:
+- pwd
+- matlab -batch "r = runtests('gemini3d.tests'); assert(~isempty(r)); assertSuccess(r)"

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,5 +29,4 @@ before_script:
 - export PATH=/snap/bin:$PATH
 
 script:
-- pwd
 - matlab -batch "r = runtests('gemini3d.tests'); assert(~isempty(r)); assertSuccess(r)"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
-dist: focal
+dist: bionic
+# Matlab R2020a libstdc++ needs Ubuntu 18.04
 
 language: matlab
 
@@ -14,5 +15,12 @@ addons:
     packages:
     - gfortran
     - libhdf5-dev
+    - liblapack-dev
     - libopenmpi-dev
     - libmumps-dev
+  snaps:
+  - name: cmake
+    confinement: classic
+
+before_script:
+- export PATH=/snap/bin:$PATH

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+dist: focal
+
+language: matlab
+
+matlab:
+- latest
+
+git:
+- depth: 3
+- quiet: true
+
+addons:
+  apt:
+    packages:
+    - gfortran
+    - libhdf5-dev
+    - libopenmpi-dev
+    - libmumps-dev

--- a/Readme.md
+++ b/Readme.md
@@ -38,7 +38,7 @@ Matlab R2020a Update 5 and newer have better plot quality due to new Matlab grap
 4. To run the self-tests from Matlab in the mat_gemini/ directory:
 
     ```matlab
-    test_gemini
+    runtests(gemini3d.tests)
     ```
 
 ## Usage

--- a/Readme.md
+++ b/Readme.md
@@ -38,7 +38,21 @@ Matlab R2020a Update 5 and newer have better plot quality due to new Matlab grap
 4. To run the self-tests from Matlab in the mat_gemini/ directory:
 
     ```matlab
-    runtests(gemini3d.tests)
+    runtests('gemini3d.tests')
+    ```
+
+If the "runtests" dryrun fails with SSL certificate errors, you may need to tell Git the locatiion of your system SSL certificates. This can be an issue in general on HPC.
+If this is an issue, and assuming your SSL certificates are at "/etc/ssl/certs/ca-bundle.crt", do these two steps from Terminal (not Matlab), one time.
+
+1. edit ~/.bashrc to have
+
+    ```sh
+    export SSL_CERT_FILE=/etc/ssl/certs/ca-bundle.crt
+    ```
+2. issue Terminal command:
+
+    ```sh
+    git config --global http.sslCAInfo /etc/ssl/certs/ca-bundle.crt
     ```
 
 ## Usage

--- a/Readme.md
+++ b/Readme.md
@@ -3,6 +3,7 @@
 ![ci](https://github.com/gemini3d/mat_gemini/workflows/ci/badge.svg)
 [![DOI](https://zenodo.org/badge/246748210.svg)](https://zenodo.org/badge/latestdoi/246748210)
 [![View MatGemini on File Exchange](https://www.mathworks.com/matlabcentral/images/matlab-file-exchange.svg)](https://www.mathworks.com/matlabcentral/fileexchange/78676-matgemini)
+[![Build Status](https://travis-ci.com/gemini3d/mat_gemini.svg?branch=master)](https://travis-ci.com/gemini3d/mat_gemini)
 
 These scripts form the basic core needed to work with Gemini3D ionospheric model to:
 

--- a/setup.m
+++ b/setup.m
@@ -14,7 +14,7 @@ if isempty(gemini_root)
 
   ret = 0;
   if ~isfolder(gemini_root)
-    cmd = "git -C " + fullfile(gemini_root, "..") + " clone " + gemini3d_git + " " + gemini3d_dirname;
+    cmd = "git -C " + fullfile(cwd, "..") + " clone " + gemini3d_git + " " + gemini3d_dirname;
     ret = system(cmd);
   end
 

--- a/test_gemini.m
+++ b/test_gemini.m
@@ -1,2 +1,0 @@
-suite = matlab.unittest.TestSuite.fromPackage('gemini3d.tests');
-run(suite)


### PR DESCRIPTION
* add Travis-CI Matlab automatic tests
* make path handling more robust across operating systems for path separators and path traversal (issues identified thanks to Travis-CI)